### PR TITLE
Fixes plus port to WeeWX 4.x

### DIFF
--- a/readme
+++ b/readme
@@ -3,6 +3,7 @@ Copyright 2016 Matthew Wall
 Distributed under terms of the GPLv3
 
 This is a weewx driver that gets data from a Rainwise IP-100.
+Tested against IP100 firmware 2082.
 
 
 ===============================================================================
@@ -39,3 +40,10 @@ Use the host and port options to tell the driver where to find the IP-100:
     port = 80
     host = 192.168.1.12
     poll_interval = 2 # how often to query the IP-100, in seconds
+    # The number of seconds to wait for the newtork to come up.
+    # (Useful on a Raspberry Pi, 10s recommended.)
+    wait_for_network = 0
+    # The number of times to try to read from the IP100 before giving up.
+    max_tries = 3
+    # The number of seconds to wait before retrying a read from the IP100.
+    retry_wait = 5

--- a/test/output.xml
+++ b/test/output.xml
@@ -3,14 +3,14 @@
 <status>
  <hardware>
    <serial_number></serial_number>
-   <firmware_version>1074</firmware_version>
-   <clock>2016/08/01 15:51:52</clock>
-   <station_volts>7.0</station_volts>
+   <firmware_version>2082</firmware_version>
+   <clock>2020/01/22 18:26:05</clock>
+   <station_volts>6.7</station_volts>
    <network>
-     <MAC_address>0090C2DE0164</MAC_address>
-     <IP_address>192.168.10.101</IP_address>
-     <subnet>255.255.255.0</subnet>
-     <gateway>192.168.10.1</gateway>
+   		<MAC_address>000000000000</MAC_address>
+   		<IP_address>192.168.168.176</IP_address>
+		<subnet>255.255.255.0</subnet>
+		<gateway>192.168.168.1</gateway>
    </network>
    <interval>1</interval>
    <base_units>English</base_units>
@@ -18,45 +18,51 @@
  </hardware>
 
  <weather>
-   <temperature_outside>
-     <current>75.1</current>
-     <max>81.1</max>
-     <min>54.6</min>
-     </temperature_outside>
+	<temperature_outside>
+		<current>52.8</current>
+		<max>65.1</max>
+		<min>52.0</min>
+	</temperature_outside>
 
-   <humidity>
-     <current>57</current>
-     <max>99</max>
-     <min>47</min>
-     </humidity>
+	<humidity>
+		<current>89</current>
+		<max>99</max>
+		<min>71</min>
+	</humidity>
 
-   <pressure>
-     <current>30.13</current>
-     <max>30.17</max>
-     <min>30.12</min>
-     </pressure>
+	<pressure>
+		<current>30.22</current>
+		<max>30.28</max>
+		<min>30.17</min>
+	</pressure>
 
-   <precipitation>
-     <current>0.00</current>
-     </precipitation>
+	<precipitation>
+		<current>0.03</current>
+	</precipitation>
 
-   <wind>
-     <speed>1.2</speed>
-     <direction>247</direction>
-     <gust_speed>7.0</gust_speed>
-     <gust_direction>247</gust_direction>
-     </wind>
+	<wind>
+		<speed>0.0</speed>
+		<direction>292</direction>
+		<gust_speed>0.0</gust_speed>
+		<gust_direction>292</gust_direction>
+	</wind>
 
-   <temperature_inside>
-     <current>73.0</current>
-     <max>77.0</max>
-     <min>71.0</min>
-     </temperature_inside>
-   
-   <solar_radiation>
-     <current>229</current>
-     <max>15743696</max>
-     <min></min>
-   </solar_radiation>
+	<temperature_inside>
+		<current>67.0</current>
+		<max>68.0</max>
+		<min>62.0</min>
+	</temperature_inside>
+	
+		
+	
+	
+	
+	
+	 
+	 	
+		
+	 	
+	
+	 	
  </weather>
 </status>

--- a/test/output.xml
+++ b/test/output.xml
@@ -52,17 +52,11 @@
 		<max>68.0</max>
 		<min>62.0</min>
 	</temperature_inside>
-	
-		
-	
-	
-	
-	
-	 
-	 	
-		
-	 	
-	
-	 	
+
+	<solar_radiation>
+		<current>229</current>
+		<max>15743696</max>
+		<min></min>
+	</solar_radiation>
  </weather>
 </status>


### PR DESCRIPTION
Hi Matthew,

I run an instance of WeeWX with the IP100 (in addition to two using the CC3000).  I’ve been running with the changes below (sans 4.x changes) for about 10 months.  The WeeWX 4.x changes since December.

Sending a pull request in case you are interested in this.

Cheers,
John

Fixes:
IP100 reports day_rain_total, not rain.
Catch URLError so WeeWX doesn’t exit if IP100 is temporarily unplugged (sleeps and retries).

WeeWX 4.x
Works with (and requires) WeeWX 4.x.  Works with Py2 and Py3.

Additions
Add wait_for_network to sleep at startup.  Convenient for Raspberry Pi where network arrives late.

Tested with IP100 firmware 2082.  Updated the test file to the 2082 version, but there are no changes other than the firmware reported.